### PR TITLE
Potential fix for code scanning alert no. 11: Useless assignment to local variable

### DIFF
--- a/_rules/sort_depends.ts
+++ b/_rules/sort_depends.ts
@@ -182,7 +182,6 @@ function* splitDependsGroup(payload: RuleSortDependsSorterPayload, node: Deno.li
 	}
 	if (result.length > 0) {
 		yield result;
-		result = [];
 	}
 }
 export default {


### PR DESCRIPTION
Potential fix for [https://github.com/hugoalh/deno-lint-rules/security/code-scanning/11](https://github.com/hugoalh/deno-lint-rules/security/code-scanning/11)

To fix this, remove the dead assignment `result = []` in the final tail block of `splitDependsGroup` (the block after the loop). Keep the earlier in-loop reset at line 180, because that one is needed for continued grouping in subsequent loop iterations.

Best single fix (no behavior change):
- File: `_rules/sort_depends.ts`
- Region: `splitDependsGroup(...)`, final `if (result.length > 0)` block
- Change: delete `result = [];` after `yield result;`
- No imports, new methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
