### PR TITLE
Potential fix for code scanning alert no. 10: Inefficient regular expression

### DIFF
--- a/_utility.ts
+++ b/_utility.ts
@@ -161,7 +161,7 @@ export interface NodeNearbyRawContext {
 	before: ContextSlice | null;
 	full: ContextSlice;
 }
-const regexpNodeNearbyAfter = /^(?:[\t ]*;?)*[\t ]*\r?$/;
+const regexpNodeNearbyAfter = /^[\t ]*(?:;[\t ]*)*\r?$/;
 export function getNodeNearbyRaw(context: Deno.lint.RuleContext, node: Deno.lint.Node): NodeNearbyRawContext {
 	let before: ContextSlice | null = null;
 	const comments: readonly (Deno.lint.LineComment | Deno.lint.BlockComment)[] = context.sourceCode.getCommentsBefore(node);


### PR DESCRIPTION
Potential fix for [https://github.com/hugoalh/deno-lint-rules/security/code-scanning/10](https://github.com/hugoalh/deno-lint-rules/security/code-scanning/10)

To fix this, remove the nested ambiguous repetition while preserving accepted strings.  
Current intent appears to be: accept only tabs/spaces, optional semicolons possibly separated by tabs/spaces, optional trailing `\r`, and nothing else.

A safe equivalent is:
- `^[\t ]*(?:;[\t ]*)*\r?$`

Why this works:
- It allows initial whitespace.
- Then zero or more occurrences of `;` followed by whitespace.
- No nested `*` over another `*`, so backtracking ambiguity is removed.
- Behavior remains functionally equivalent for the current use (`test(afterIndexSlice)`).

Change only `_utility.ts` at the regex declaration line (line 164 region). No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
